### PR TITLE
Only set verbose flag of curl if debug flag of findmyiphone is sat.

### DIFF
--- a/class.findmyiphone.php
+++ b/class.findmyiphone.php
@@ -237,7 +237,8 @@ TABLEFOOTER;
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");                                                                     
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $body);                                                                  
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_VERBOSE, 1);
+		if ($this->debug)
+			curl_setopt($ch, CURLOPT_VERBOSE, 1);
 		curl_setopt($ch, CURLOPT_HEADER, 1);
 		curl_setopt($ch, CURLOPT_USERAGENT, $this->client["user-agent"]);
 		if (strlen($authentication) > 0) {


### PR DESCRIPTION
Im not sure if the verbose output of curl will be shown if used as part of a web app, but it frankly made it impossible to use as part of a cli-application.